### PR TITLE
Make error messages readable by VoiceOver and JAWS

### DIFF
--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -190,7 +190,7 @@
                    placeholder="[[placeholder]]"
                    invalid="{{invalid}}"
 
-                   role="textbox"
+                   type="text"
                    aria-autocomplete="list"
                    aria-multiline="false"
                    aria-activedescendant$="[[_highlightedSuggestion.elementId]]"


### PR DESCRIPTION
Change role="textbox" to type="text" in order to allow VoiceOver and JAWS screen readers to read error messages, per recommendations at: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role